### PR TITLE
feat : 캘린더에서 예약 목록 출력 및 예약 일자 표시

### DIFF
--- a/src/Navigation/BottomNavigationBar.tsx
+++ b/src/Navigation/BottomNavigationBar.tsx
@@ -53,20 +53,6 @@ const BottomTabNavigator = () => {
         headerShown: false, // 상단 바를 없애는 옵션
       }}>
       <Tab.Screen
-        name="Chat"
-        component={Chat}
-        options={{
-          tabBarIcon: ({focused}) => (
-            <Icon
-              name={'chatbubbles-outline'}
-              size={30}
-              color={focused ? '#242da1' : 'black'}
-            />
-          ),
-          tabBarLabel: () => null,
-        }}
-      />
-      <Tab.Screen
         name="Home"
         component={HomeStack}
         options={{
@@ -87,6 +73,20 @@ const BottomTabNavigator = () => {
           tabBarIcon: ({focused}) => (
             <Icon
               name={'search'}
+              size={30}
+              color={focused ? '#242da1' : 'black'}
+            />
+          ),
+          tabBarLabel: () => null,
+        }}
+      />
+      <Tab.Screen
+        name="Chat"
+        component={Chat}
+        options={{
+          tabBarIcon: ({focused}) => (
+            <Icon
+              name={'chatbubbles-outline'}
               size={30}
               color={focused ? '#242da1' : 'black'}
             />

--- a/src/apis/AuthorReserve/getAuthorReserveDay.ts
+++ b/src/apis/AuthorReserve/getAuthorReserveDay.ts
@@ -1,9 +1,9 @@
-//특정 일의 예약 유무를 조회(Get)
+//작가의 특정 일의 예약 유무를 조회(Get)
 import axios from 'axios';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import apiClient from '../getAccessToken';
 
-export const fetchReserveDay = async day => {
+export const fetchAuthorReserveDay = async day => {
   try {
     const accessToken = await AsyncStorage.getItem('accessToken');
     if (!accessToken) {
@@ -16,7 +16,7 @@ export const fetchReserveDay = async day => {
     };
     // axios 요청 보내기
     const response = await apiClient.get(
-      'https://api.catsnap.net/reservation/member/my/day',
+      'https://api.catsnap.net/reservation/photographer/my/day',
       {
         headers: {
           Authorization: `Bearer ${accessToken}`,

--- a/src/apis/AuthorReserve/getAuthorReserveMonth.ts
+++ b/src/apis/AuthorReserve/getAuthorReserveMonth.ts
@@ -1,9 +1,9 @@
-//특정 일의 예약 유무를 조회(Get)
+//작가의 특정 월의 예약 유무를 일별로 조회(Get)
 import axios from 'axios';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import apiClient from '../getAccessToken';
 
-export const fetchReserveDay = async day => {
+export const fetchAuthorReserveMonth = async month => {
   try {
     const accessToken = await AsyncStorage.getItem('accessToken');
     if (!accessToken) {
@@ -12,11 +12,11 @@ export const fetchReserveDay = async day => {
     }
 
     const params = {
-      day: day,
+      month: month,
     };
     // axios 요청 보내기
     const response = await apiClient.get(
-      'https://api.catsnap.net/reservation/member/my/day',
+      'https://api.catsnap.net/reservation/photographer/my/month',
       {
         headers: {
           Authorization: `Bearer ${accessToken}`,

--- a/src/apis/ReserveProgram/getPrograms.ts
+++ b/src/apis/ReserveProgram/getPrograms.ts
@@ -6,12 +6,6 @@ import apiClient from '../getAccessToken';
 
 export const fetchPrograms = async (photographerId: number) => {
   try {
-    const accessToken = await AsyncStorage.getItem('accessToken');
-    if (!accessToken) {
-      console.error('액세스 토큰이 없습니다.');
-      return null;
-    }
-
     const params = {
       photographerId: photographerId,
     };
@@ -20,7 +14,7 @@ export const fetchPrograms = async (photographerId: number) => {
       'https://api.catsnap.net/reservation/photographer/program',
       {
         headers: {
-          Authorization: `Bearer ${accessToken}`,
+          Authorization: 'Bearer ',
         },
         params: params,
       },

--- a/src/apis/ReserveProgram/getReserveGuide.ts
+++ b/src/apis/ReserveProgram/getReserveGuide.ts
@@ -6,12 +6,6 @@ import apiClient from '../getAccessToken';
 
 export const fetchReserveGuide = async (photographerId: number) => {
   try {
-    const accessToken = await AsyncStorage.getItem('accessToken');
-    if (!accessToken) {
-      console.error('액세스 토큰이 없습니다.');
-      return null;
-    }
-
     const params = {
       photographerId: photographerId,
     };
@@ -20,7 +14,7 @@ export const fetchReserveGuide = async (photographerId: number) => {
       'https://api.catsnap.net/reservation/photographer/guidance',
       {
         headers: {
-          Authorization: `Bearer ${accessToken}`,
+          Authorization: 'Bearer ',
         },
         params: params,
       },

--- a/src/components/Calendar/Style.ts
+++ b/src/components/Calendar/Style.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components/native';
+import styled, {css} from 'styled-components/native';
 import {View, Text, Pressable, TouchableOpacity} from 'react-native';
 
 export const MyCalendar = styled(View)`
@@ -47,4 +47,86 @@ export const DateText = styled(Text)`
 export const DateView = styled(View)`
   align-items: left;
   margin: 3% 7%;
+`;
+export const Cell = styled(TouchableOpacity)`
+  width: 14.28%;
+  aspect-ratio: 1;
+  height: 60px;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const CellBackground = styled(View)`
+  width: 40px;
+  height: 40px;
+  justify-content: center;
+  align-items: center;
+  background-color: ${({isReserved}) =>
+    isReserved ? 'rgb(229, 225, 252)' : 'transparent'};
+  border-radius: ${({isReserved}) => (isReserved ? '10px' : '0px')};
+`;
+
+export const CellText = styled.Text<{
+  colIndex: number;
+  rowIndex: number;
+  isInCurrentMonth: boolean;
+  selectedDay: number | null;
+  todayDay: number | null;
+  itemDay: number | null;
+}>`
+  color: #000;
+  font-size: 17px;
+  font-weight: bold;
+
+  ${({colIndex}) =>
+    colIndex === 0 &&
+    css`
+      color: #ff0000; /* 일요일 빨간색 */
+    `}
+
+  ${({colIndex}) =>
+    colIndex === 6 &&
+    css`
+      color: #007ba4; /* 토요일 파란색 */
+    `}
+
+  ${({isInCurrentMonth}) =>
+    !isInCurrentMonth &&
+    css`
+      color: #d3d3d3; /* 현재 달이 아닌 날짜 회색 */
+    `}
+
+  ${({selectedDay, isInCurrentMonth, itemDay}) =>
+    selectedDay === itemDay &&
+    isInCurrentMonth &&
+    css`
+      background-color: #e6eef5; /* 선택된 날짜 배경색 */
+      border-radius: 10px;
+      width: 40px;
+      height: 40px;
+      text-align: center;
+      line-height: 40px;
+      color: #000;
+    `}
+
+  ${({todayDay, isInCurrentMonth, itemDay}) =>
+    todayDay === itemDay &&
+    isInCurrentMonth &&
+    css`
+      background-color: #3e23b9; /* 오늘 날짜 배경색 */
+      border-radius: 10px;
+      width: 40px;
+      height: 40px;
+      text-align: center;
+      line-height: 40px;
+      color: #fff; /* 보라색 배경에 흰색 텍스트 */
+    `}
+
+  ${({rowIndex}) =>
+    rowIndex === 0 &&
+    css`
+      font-size: 15px;
+      font-weight: bold;
+      color: #555; /* 요일 헤더 스타일 */
+    `}
 `;

--- a/src/components/Login/Style.ts
+++ b/src/components/Login/Style.ts
@@ -9,10 +9,10 @@ export const LoginBtnContainer = styled(TouchableOpacity)`
   font-size: 18px;
   align-items: center;
   justify-content: center;
-  font-weight: bold;
 `;
 
 export const BtnText = styled(Text)`
   color: white;
-  font-size: 18px;
+  font-size: 14px;
+  font-weight: bold;
 `;

--- a/src/components/Profile/AuthorProfile/AuthorProfileComponent.tsx
+++ b/src/components/Profile/AuthorProfile/AuthorProfileComponent.tsx
@@ -1,4 +1,4 @@
-//작가의 마이페이지를 보여주는 컴포넌트
+//작가로 로그인시 작가의 마이페이지를 보여주는 컴포넌트
 import React, {useState, useEffect, useCallback} from 'react';
 import {
   SafeAreaView,
@@ -14,13 +14,17 @@ import SearchTag from '../../Search/SearchTag.tsx/SearchTag';
 import {useNavigation, useFocusEffect} from '@react-navigation/native';
 import {fetchReservationPrograms} from '../../../apis/ReserveProgram/getReserveProgram';
 import LoginBtn from '../../Login/LoginBtn';
+import {fetchReserveGuide} from '../../../apis/ReserveProgram/getReserveGuide';
+import {useSelector} from 'react-redux';
 
 const AuthorProfileComponent = () => {
   const navigation = useNavigation(); // 네비게이션 객체 가져오기
   const [isTouchOne, setIsTouchOne] = useState(false);
   const [isTouchTwo, setIsTouchTwo] = useState(false);
-
+  const [guide, setGuide] = useState(null); // 객체로 상태를 저장
   const [programs, setPrograms] = useState([]); // 프로그램 데이터를 저장할 상태
+  const isAuthor = useSelector(state => state.auth.user?.isAuthor);
+  const user = useSelector(state => state.auth.user);
 
   // 작가 탭 항목 터치 시 항목 출력
   const handleFeed = () => {
@@ -29,12 +33,22 @@ const AuthorProfileComponent = () => {
   };
 
   const handleProfile = () => {
-    setIsTouchTwo(prevState => !prevState); // 상태를 토글
     Alert.alert('프로필 공유 페이지');
+    setIsTouchTwo(prevState => !prevState); // 상태를 토글
   };
 
-  const handleProgram = (programId: Number) => {
-    navigation.navigate('ReserveProgramPage', {programId});
+  const handleProgram = (
+    programId: Number,
+    title: string,
+    price: Number,
+    content: string,
+  ) => {
+    navigation.navigate('ReserveProgramPage', {
+      programId,
+      title,
+      price,
+      content,
+    });
   };
 
   const handleCreateProgram = () => {
@@ -45,19 +59,26 @@ const AuthorProfileComponent = () => {
   const loadPrograms = async () => {
     try {
       const response = await fetchReservationPrograms();
-      if (response?.data?.photographerProgramList) {
-        setPrograms(response.data.photographerProgramList);
-      } else {
-        console.error('프로그램 데이터를 불러오지 못했습니다.');
-      }
+      setPrograms(response.data.photographerProgramList);
     } catch (error) {
       console.error('프로그램 데이터를 불러오는 중 오류 발생:', error);
     }
   };
 
+  //장소와 주의사항 데이터를 가져오려면 photographerID가 필요함,
+  //이 값을 가져오는 api 필요
+  // API 호출로 장소와 주의사항 데이터 가져오기
+  /*const loadGuide = async () => {
+    try {
+      const response2 = await fetchReserveGuide(isAuthor);
+      setGuide(response2.data);
+    } catch (error) {
+      console.error('가이드 데이터를 불러오는 중 오류 발생:', error);
+    }
+  };
   // 페이지가 focus될 때마다 프로그램 데이터를 다시 로드
   //이렇게 해야 새로 만든 프로그램이 바로 업데이트가 된다
-
+*/
   useFocusEffect(
     useCallback(() => {
       loadPrograms();
@@ -99,7 +120,14 @@ const AuthorProfileComponent = () => {
           programs.map(program => (
             <S.ContentsBox
               key={program.programId}
-              onPress={() => handleProgram(program.programId)}>
+              onPress={() =>
+                handleProgram(
+                  program.programId,
+                  program.title,
+                  program.price,
+                  program.content,
+                )
+              }>
               <S.Contents>{program.title}</S.Contents>
               <S.Price>{program.price}원</S.Price>
             </S.ContentsBox>

--- a/src/components/Reserve/ReserveComponent/ReserveAuthorBox/ReserveAuthorBox.tsx
+++ b/src/components/Reserve/ReserveComponent/ReserveAuthorBox/ReserveAuthorBox.tsx
@@ -1,0 +1,29 @@
+//달력에서 보이는 예약 목록 컴포넌트 박스 입니다.(작가용)
+import React from 'react';
+import {SafeAreaView, Text, StyleSheet, ScrollView, View} from 'react-native';
+import * as S from './Style';
+
+const ReserveAuthorBox = ({item}) => {
+  return (
+    <SafeAreaView>
+      <S.ReserveContainer state={item.state}>
+        <S.ReserveText>
+          {item.startTime[3]}:
+          {item.startTime[4] === 0 ? '00' : item.startTime[4]}
+        </S.ReserveText>
+        <S.Line />
+        <S.ReserveTitleText>
+          {item.reservedProgramResponse.title}
+        </S.ReserveTitleText>
+        <S.Box>
+          <S.ReserveText>
+            {item.memberTinyInformationResponse.nickname} 유저
+          </S.ReserveText>
+          <Text>장소 : {item.reservationLocation.locationName}</Text>
+        </S.Box>
+      </S.ReserveContainer>
+    </SafeAreaView>
+  );
+};
+
+export default ReserveAuthorBox;

--- a/src/components/Reserve/ReserveComponent/ReserveAuthorBox/Style.ts
+++ b/src/components/Reserve/ReserveComponent/ReserveAuthorBox/Style.ts
@@ -1,0 +1,49 @@
+import styled from 'styled-components/native';
+import {View, Text, TouchableOpacity} from 'react-native';
+export const ReserveContainer = styled(TouchableOpacity)`
+  flex: 1;
+  flex-direction: row;
+  background-color: ${({state}) => {
+    switch (state) {
+      case 'PENDING':
+        return 'rgb(225, 224, 236)';
+      case 'APPROVED':
+        return 'rgb(188, 187, 233)';
+      case 'REJECTED':
+        return 'rgb(250, 135, 114)';
+      case 'MEMBER_CANCELLED':
+        return 'rgb(211, 211, 211)'; // 취소된 예약
+      case 'PHOTOGRAPHY_CANCELLED':
+        return 'rgb(211, 211, 211)'; // 작가가 취소한 예약
+      default:
+        return 'rgb(188, 187, 233)'; // 기본 배경색
+    }
+  }};
+  margin: 2% 5%;
+  border-radius: 15px;
+  padding: 5%;
+  justify-content: space-evenly;
+  gap: 10px;
+  align-items: center;
+`;
+export const ReserveTitleText = styled(Text)`
+  font-size: 25px;
+  color: black;
+  font-weight: bold;
+`;
+export const ReserveText = styled(Text)`
+  font-size: 20px;
+  color: black;
+  font-weight: bold;
+`;
+
+export const Line = styled(View)`
+  width: 5px;
+  height: 35px;
+  background-color: #423cd2;
+`;
+
+export const Box = styled(View)`
+  flex: 1;
+  flex-direction: column;
+`;

--- a/src/components/Reserve/ReserveComponent/ReserveUserBox/ReserveUserBox.tsx
+++ b/src/components/Reserve/ReserveComponent/ReserveUserBox/ReserveUserBox.tsx
@@ -1,0 +1,27 @@
+//달력에서 보이는 예약 목록 컴포넌트 박스 입니다.(작가용)
+import React from 'react';
+import {SafeAreaView, Text, StyleSheet, ScrollView, View} from 'react-native';
+import * as S from './Style';
+
+const ReserveUserBox = ({item}) => {
+  const time = item.startTime.split(' ')[1]; // 날짜를 분리하고 시간만 추출
+  return (
+    <SafeAreaView>
+      <S.ReserveContainer state={item.state}>
+        <S.ReserveText>{time}</S.ReserveText>
+        <S.Line />
+        <S.ReserveTitleText>
+          {item.reservedProgramResponse.title}
+        </S.ReserveTitleText>
+        <S.Box>
+          <S.ReserveText>
+            {item.photographerTinyInformationResponse.nickname} 작가
+          </S.ReserveText>
+          <Text>장소 : {item.reservationLocation.locationName}</Text>
+        </S.Box>
+      </S.ReserveContainer>
+    </SafeAreaView>
+  );
+};
+
+export default ReserveUserBox;

--- a/src/components/Reserve/ReserveComponent/ReserveUserBox/Style.ts
+++ b/src/components/Reserve/ReserveComponent/ReserveUserBox/Style.ts
@@ -1,0 +1,49 @@
+import styled from 'styled-components/native';
+import {View, Text, TouchableOpacity} from 'react-native';
+export const ReserveContainer = styled(TouchableOpacity)`
+  flex: 1;
+  flex-direction: row;
+  background-color: ${({state}) => {
+    switch (state) {
+      case 'PENDING':
+        return 'rgb(225, 224, 236)';
+      case 'APPROVED':
+        return 'rgb(188, 187, 233)';
+      case 'REJECTED':
+        return 'rgb(250, 135, 114)';
+      case 'MEMBER_CANCELLED':
+        return 'rgb(211, 211, 211)'; // 취소된 예약
+      case 'PHOTOGRAPHY_CANCELLED':
+        return 'rgb(211, 211, 211)'; // 작가가 취소한 예약
+      default:
+        return 'rgb(188, 187, 233)'; // 기본 배경색
+    }
+  }};
+  margin: 2% 5%;
+  border-radius: 15px;
+  padding: 5%;
+  justify-content: space-evenly;
+  gap: 10px;
+  align-items: center;
+`;
+export const ReserveTitleText = styled(Text)`
+  font-size: 25px;
+  color: black;
+  font-weight: bold;
+`;
+export const ReserveText = styled(Text)`
+  font-size: 20px;
+  color: black;
+  font-weight: bold;
+`;
+
+export const Line = styled(View)`
+  width: 5px;
+  height: 35px;
+  background-color: #423cd2;
+`;
+
+export const Box = styled(View)`
+  flex: 1;
+  flex-direction: column;
+`;

--- a/src/pages/AuthorProfile/AuthorProfile.tsx
+++ b/src/pages/AuthorProfile/AuthorProfile.tsx
@@ -1,5 +1,5 @@
 //다른 사람의 프로필을 보여주는 페이지 입니다.
-//사용자가 작가의 프로필 페이지(소개 페이지)를 볼 수 있습니다.
+//사용자가 작가의 프로필 페이지(소개 페이지)를 볼 수 있습니다.(사용자->작가)
 import React, {useState, useCallback, useEffect} from 'react';
 import {
   SafeAreaView,
@@ -39,6 +39,9 @@ const AuthorProfile = () => {
     Alert.alert('작가를 차단하였습니다.');
   };
 
+  //현재 작가 아이디는 하드코딩된 상황, 이후 api 추가시 고칠 것
+  const photographerId = 2;
+
   const handleProgram = (
     programId: Number,
     title: string,
@@ -54,34 +57,21 @@ const AuthorProfile = () => {
     });
   };
 
-  //현재 작가 아이디는 하드코딩된 상황, 이후 api 추가시 고칠 것
-  const photographerId = 2;
-
   // API 호출로 프로그램 데이터 가져오기
   const loadPrograms = async () => {
     try {
       const response = await fetchPrograms(photographerId);
-      if (response?.data?.photographerProgramList) {
-        setPrograms(response.data.photographerProgramList);
-      } else {
-        console.error('프로그램 데이터를 불러오지 못했습니다.');
-      }
+      setPrograms(response.data.photographerProgramList);
     } catch (error) {
       console.error('프로그램 데이터를 불러오는 중 오류 발생:', error);
     }
   };
 
-  // API 호출로 프로그램 데이터 가져오기
+  // API 호출로 장소와 주의사항 데이터 가져오기
   const loadGuide = async () => {
     try {
       const response2 = await fetchReserveGuide(photographerId);
-      //두 요소개 비어있으면 에러출력
-      if (
-        response2?.data?.photographerLocation &&
-        response2?.data?.photographerNotification
-      ) {
-        setGuide(response2.data);
-      }
+      setGuide(response2.data);
     } catch (error) {
       console.error('가이드 데이터를 불러오는 중 오류 발생:', error);
     }
@@ -90,7 +80,7 @@ const AuthorProfile = () => {
   useEffect(() => {
     loadPrograms();
     loadGuide();
-  }, []);
+  }, [photographerId]);
 
   return (
     <SafeAreaView style={styles.container}>
@@ -120,39 +110,89 @@ const AuthorProfile = () => {
 
           {/* 프로그램 리스트 렌더링 */}
           {programs.length === 0 ? (
-            <View>
+            <S.ContentsBoxContainer>
+              <S.ContentsAreaText2>예약 프로그램</S.ContentsAreaText2>
+              <S.Line2 />
               <S.ProgramView>
                 <S.ProgramText>등록된 프로그램이 없습니다.</S.ProgramText>
               </S.ProgramView>
-            </View>
+            </S.ContentsBoxContainer>
           ) : (
-            programs.map(program => (
-              <S.ContentsBox
-                key={program.programId}
-                onPress={() =>
-                  handleProgram(
-                    program.programId,
-                    program.title,
-                    program.price,
-                    program.content,
-                  )
-                }>
-                <S.Contents>{program.title}</S.Contents>
-                <S.Price>{program.price}원</S.Price>
-              </S.ContentsBox>
-            ))
+            <View>
+              <S.ContentsBoxContainer>
+                <S.ContentsAreaText2>예약 목록</S.ContentsAreaText2>
+                <S.Line2 />
+                {programs.map(program => (
+                  <S.ContentsBox
+                    key={program.programId}
+                    onPress={() =>
+                      handleProgram(
+                        program.programId,
+                        program.title,
+                        program.price,
+                        program.content,
+                      )
+                    }>
+                    <S.Contents>{program.title}</S.Contents>
+                    <S.Price>{program.price}원</S.Price>
+                  </S.ContentsBox>
+                ))}
+              </S.ContentsBoxContainer>
+            </View>
           )}
 
           {!guide ? (
             <View>
               <S.ProgramView>
-                <S.ProgramText>등록된 가이드가 없습니다.</S.ProgramText>
+                <S.ProgramText>등록된 정보가 없습니다.</S.ProgramText>
               </S.ProgramView>
             </View>
           ) : (
             <View>
-              <S.Contents>장소: {guide.photographerLocation}</S.Contents>
-              <S.Contents>{guide.photographerNotification}</S.Contents>
+              {!guide.photographerLocation ? (
+                <S.ContentsAreaBox>
+                  <S.ContentsAreaText>장소</S.ContentsAreaText>
+
+                  <S.Line />
+                  <S.Box>
+                    <S.ProgramView>
+                      <S.ProgramText>등록된 장소가 없습니다.</S.ProgramText>
+                    </S.ProgramView>
+                  </S.Box>
+                </S.ContentsAreaBox>
+              ) : (
+                <S.ContentsAreaBox>
+                  <S.ContentsAreaText>장소</S.ContentsAreaText>
+                  <S.Line />
+                  <S.Box>
+                    <S.ContentsAreaText3>
+                      {guide.photographerLocation}
+                    </S.ContentsAreaText3>
+                  </S.Box>
+                </S.ContentsAreaBox>
+              )}
+              {!guide.photographerNotification ? (
+                <S.ContentsAreaBox>
+                  <S.ContentsAreaText>주의사항</S.ContentsAreaText>
+                  <S.Line />
+                  <S.Box>
+                    <S.ProgramView>
+                      <S.ProgramText>등록된 주의사항이 없습니다.</S.ProgramText>
+                    </S.ProgramView>
+                  </S.Box>
+                </S.ContentsAreaBox>
+              ) : (
+                <S.ContentsAreaBox>
+                  <S.ContentsAreaText>주의사항</S.ContentsAreaText>
+
+                  <S.Line />
+                  <S.Box>
+                    <S.ContentsAreaText3>
+                      {guide.photographerNotification}
+                    </S.ContentsAreaText3>
+                  </S.Box>
+                </S.ContentsAreaBox>
+              )}
             </View>
           )}
 

--- a/src/pages/AuthorProfile/Style.ts
+++ b/src/pages/AuthorProfile/Style.ts
@@ -69,11 +69,17 @@ export const AuthorFeedProfile = styled(Text)`
 export const ContentsBox = styled(TouchableOpacity)`
   flex-direction: row;
   justify-content: space-between;
-  margin: 1% 0;
+  margin: 1% 3%;
+`;
+export const ContentsBoxContainer = styled(View)`
+  background-color: #f3f3f3;
+  margin: 3% 0%;
+  padding: 3% 3%;
+  border-radius: 15px;
 `;
 
 export const Contents = styled(Text)`
-  color: #747272;
+  color: black;
 `;
 export const Price = styled(Text)`
   color: black;
@@ -114,8 +120,51 @@ export const PostContainer = styled(View)`
 export const ProgramText = styled(Text)`
   margin: 10% 0;
   color: gray;
-  font-size: 20px;
+  font-size: 18px;
 `;
 export const ProgramView = styled(View)`
   align-items: center;
+`;
+export const ContentsAreaBox = styled(View)`
+  background-color: #f3f3f3;
+  border-radius: 15px;
+  padding: 3%;
+  margin: 2% 0%;
+  flex-direction: row;
+  align-items: center;
+`;
+export const ContentsAreaText = styled(Text)`
+  color: black;
+  font-weight: bold;
+  font-size: 18px;
+  margin: 2% 2%;
+  width: 25%;
+`;
+export const ContentsAreaText2 = styled(Text)`
+  color: black;
+  font-weight: bold;
+  font-size: 18px;
+  margin: 2% 2%;
+`;
+
+export const ContentsAreaText3 = styled(Text)`
+  color: black;
+  font-size: 18px;
+  margin: 2% 2%;
+`;
+export const Line = styled(View)`
+  width: 3px;
+  height: 100%;
+  background-color: #423cd2;
+  margin: 0% 3%;
+`;
+
+export const Line2 = styled(View)`
+  width: 100%;
+  height: 3px;
+  margin: 3% 0%;
+  background-color: #423cd2;
+`;
+export const Box = styled(View)`
+  width: 65%;
 `;

--- a/src/pages/CreateProgram/CreateProgramPage.tsx
+++ b/src/pages/CreateProgram/CreateProgramPage.tsx
@@ -52,38 +52,45 @@ const ReserveProgram = () => {
   }, [title, content, price]);
 
   return (
-    <SafeAreaView>
-      <ContentsHeader text={'프로그램 생성'} />
-      <Text>
-        예약 프로그램을 생성할 수 있습니다. 이곳은 예약 프로그램을 생성해
-        추가합니다.
-      </Text>
-      <Text>타이틀</Text>
-      <TextInput
-        value={title}
-        onChangeText={setTitle}
-        placeholder="타이틀을 입력하세요"
-      />
-      <Text>내용</Text>
-      <TextInput
-        value={content}
-        onChangeText={setContent}
-        placeholder="내용을 입력하세요"
-      />
-      <Text>가격</Text>
-      <TextInput
-        value={price}
-        onChangeText={setPrice}
-        placeholder="가격을 입력하세요"
-        keyboardType="numeric"
-      />
-      <LoginBtn
-        disabled={isdisabled}
-        onPress={handleSubmitAuthor}
-        text={'프로그램 추가하기'}
-      />
+    <SafeAreaView style={styles.container}>
+      <ScrollView showsVerticalScrollIndicator={false}>
+        <ContentsHeader text={'프로그램 생성'} />
+        <S.ProgramContainer>
+          <S.Title>프로그램명</S.Title>
+          <S.InputBox
+            value={title}
+            onChangeText={setTitle}
+            textAlignVertical="top"
+          />
+          <S.Title>내용</S.Title>
+          <S.InputBox
+            value={content}
+            onChangeText={setContent}
+            textAlignVertical="top"
+            numberOfLines={5}
+          />
+          <S.Title>가격(단위 : 원)</S.Title>
+          <S.InputBox
+            value={price}
+            onChangeText={setPrice}
+            keyboardType="numeric"
+          />
+        </S.ProgramContainer>
+        <S.ProgramContainer>
+          <LoginBtn
+            disabled={isdisabled}
+            onPress={handleSubmitAuthor}
+            text={'프로그램 추가하기'}
+          />
+        </S.ProgramContainer>
+      </ScrollView>
     </SafeAreaView>
   );
 };
-
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#ffffff',
+  },
+});
 export default ReserveProgram;

--- a/src/pages/CreateProgram/Style.ts
+++ b/src/pages/CreateProgram/Style.ts
@@ -1,0 +1,19 @@
+import styled from 'styled-components/native';
+import {View, Text, Pressable, TouchableOpacity, TextInput} from 'react-native';
+
+export const Title = styled(Text)`
+  color: black;
+  font-size: 20px;
+  font-weight: bold;
+  margin: 3% 0%;
+`;
+export const InputBox = styled(TextInput)`
+  background-color: #f3f3f3;
+  border-radius: 15px;
+  font-size: 15px;
+  padding: 5% 5%;
+`;
+export const ProgramContainer = styled(View)`
+  margin: 0% 7%;
+  margin-bottom: 5%;
+`;

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -28,6 +28,11 @@ const Home = () => {
 
   // 예약 데이터를 가져오는 함수
   const getReservations = async () => {
+    if (isAuthor) {
+      return; // 작가일 경우 데이터 요청 중단
+    } else if (!isUser) {
+      return;
+    }
     try {
       const response = await fetchReservations('UPCOMING', 0, 5);
       console.log(response); // 응답 데이터 확인
@@ -44,9 +49,12 @@ const Home = () => {
   // 화면이 포커스될 때마다 예약 데이터 새로 가져오기
   useFocusEffect(
     React.useCallback(() => {
+      if (isAuthor) {
+        return;
+      } // 작가인 경우 예약 데이터를 요청하지 않음
       setLoading(true); // 로딩 상태 초기화
       getReservations(); // 데이터 새로 가져오기
-    }, []),
+    }, [isAuthor]), // isAuthor가 변경될 때마다 실행
   );
 
   // 렌더링 조건 설정

--- a/src/pages/MyCalendar/MyCalendar.tsx
+++ b/src/pages/MyCalendar/MyCalendar.tsx
@@ -1,18 +1,119 @@
 //캘린더 페이지 입니다.
-import React from 'react';
-import {SafeAreaView, View, Text, ScrollView, StyleSheet} from 'react-native';
+import React, {useState, useEffect} from 'react';
+import {
+  SafeAreaView,
+  View,
+  Text,
+  ScrollView,
+  StyleSheet,
+  FlatList,
+} from 'react-native';
 import Calendar from '../../components/Calendar/Calendar';
 import ContentsHeader from '../../components/ContentsHeader/ContentsHeader';
 import * as S from './Style';
 import Title from '../../components/Home/Title/Title';
 import {useNavigation} from '@react-navigation/native';
 import {useSelector} from 'react-redux';
-import CalendarBtn from '../../components/Calendar/CalendarBtn/CalendarBtn';
+import {fetchReserveDay} from '../../apis/UserReserve/getReserveDay';
+import {fetchAuthorReserveDay} from '../../apis/AuthorReserve/getAuthorReserveDay';
+import ReserveAuthorBox from '../../components/Reserve/ReserveComponent/ReserveAuthorBox/ReserveAuthorBox';
+import ReserveUserBox from '../../components/Reserve/ReserveComponent/ReserveUserBox/ReserveUserBox';
+import {fetchReserveMonth} from '../../apis/UserReserve/getReserveMonth';
+import {fetchAuthorReserveMonth} from '../../apis/AuthorReserve/getAuthorReserveMonth';
 
 const MyCalendar = () => {
   const isAuthor = useSelector(state => state.auth.user?.isAuthor);
   const user = useSelector(state => state.auth.user);
   const navigation = useNavigation(); // 네비게이션 객체 가져오기
+  const [date, setDate] = useState('');
+  const [reserve, setReserve] = useState([]);
+  const [month, setMonth] = useState('');
+  const [monthReserve, setMonthReserve] = useState([]);
+
+  //유저의 예약 목록(일 선택 시)
+  const dayReserveUser = async (day: string) => {
+    try {
+      const response = await fetchReserveDay(day);
+
+      setReserve(response.data.memberReservationInformationResponseList); // 올바른 데이터 설정
+    } catch (error) {
+      console.log(
+        '날짜 가져오기 실패:',
+        error.message || '알 수 없는 오류 발생',
+      );
+    }
+  };
+
+  //작가의 예약 목록 (일 선택 시)
+  const dayReserveAuthor = async (day: string) => {
+    try {
+      const response = await fetchAuthorReserveDay(day);
+
+      setReserve(response.data.photographerReservationInformationResponseList); // 올바른 데이터 설정
+    } catch (error) {
+      console.log(
+        '날짜 가져오기 실패:',
+        error.message || '알 수 없는 오류 발생',
+      );
+    }
+  };
+  // 날짜 선택 핸들러
+  const handleDateSelect = (selectedDate: string) => {
+    setDate(selectedDate); // 선택한 날짜 업데이트
+
+    //유저면 유저의 예약, 작가면 작가의 예약 업데이트
+    if (isAuthor) {
+      dayReserveAuthor(selectedDate);
+    } else if (user) {
+      dayReserveUser(selectedDate);
+    }
+  };
+
+  // 첫 렌더링 시 month가 없으면 초기화
+  useEffect(() => {
+    console.log('현재 달 가져오기');
+    const initialMonth = new Date();
+    const year = initialMonth.getFullYear();
+    const month = (initialMonth.getMonth() + 1).toString().padStart(2, '0');
+    const formattedMonth = `${year}-${month}`;
+    setMonth(formattedMonth); // month 상태 초기화
+  }, []); // 컴포넌트가 처음 렌더링될 때만 실행
+
+  // 월 데이터가 변경될 때마다 호출
+  const handleMonthChange = (monthData: Date) => {
+    console.log('달 변경');
+    const year = monthData.getFullYear();
+    const month = (monthData.getMonth() + 1).toString().padStart(2, '0');
+    const formattedMonthData = `${year}-${month}`;
+    setMonth(formattedMonthData);
+    //월 변경되면 출력된 예약 데이터도 초기화
+    setReserve([]);
+  };
+
+  useEffect(() => {
+    // 첫 렌더링 시 한 번만 호출
+    if (month) {
+      if (isAuthor) {
+        console.log(month);
+        fetchAuthorReserveMonth(month)
+          .then(response => {
+            setMonthReserve(response.data.monthReservationCheckList);
+          })
+          .catch(error => {
+            console.log('예약 정보를 가져오는 데 오류 발생:', error);
+          });
+      } else if (user) {
+        console.log(month);
+        fetchReserveMonth(month)
+          .then(response => {
+            setMonthReserve(response.data.monthReservationCheckList);
+          })
+          .catch(error => {
+            console.log('예약 정보를 가져오는 데 오류 발생:', error);
+          });
+      }
+    }
+  }, [month, isAuthor, user]); // month가 변경될 때마다 API 호출
 
   return (
     <SafeAreaView style={styles.container}>
@@ -21,18 +122,34 @@ const MyCalendar = () => {
         <S.CalendarHeader>
           <Title text={'내 예약'} />
         </S.CalendarHeader>
-        <Calendar />
-        <S.MyCalendar>
-          {isAuthor ? (
-            <S.CalendarContainer>
-              <Text>작가입니다.</Text>
-            </S.CalendarContainer>
-          ) : (
-            <View>
-              <Text>유저입니다.</Text>
-            </View>
-          )}
-        </S.MyCalendar>
+        <Calendar
+          onDateSelect={handleDateSelect}
+          onMonthChange={handleMonthChange}
+          monthReserve={monthReserve}
+        />
+        {isAuthor ? (
+          <FlatList
+            scrollEnabled={false}
+            nestedScrollEnabled={true} // ScrollView 안에서 FlatList 동작 허용
+            showsVerticalScrollIndicator={false}
+            data={reserve}
+            keyExtractor={item => String(item.reservationId)}
+            renderItem={({item}) => <ReserveAuthorBox item={item} />}
+          />
+        ) : user ? (
+          <FlatList
+            scrollEnabled={false}
+            nestedScrollEnabled={true} // ScrollView 안에서 FlatList 동작 허용
+            showsVerticalScrollIndicator={false}
+            data={reserve}
+            keyExtractor={item => String(item.reservationId)}
+            renderItem={({item}) => <ReserveUserBox item={item} />}
+          />
+        ) : (
+          <S.CalendarContainer>
+            <S.CalendarText>로그인이 필요합니다.</S.CalendarText>
+          </S.CalendarContainer>
+        )}
       </ScrollView>
     </SafeAreaView>
   );

--- a/src/pages/MyCalendar/Style.ts
+++ b/src/pages/MyCalendar/Style.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components/native';
-import {View, Text, Pressable, TouchableOpacity} from 'react-native';
+import {View, Text, Pressable, TouchableOpacity, FlatList} from 'react-native';
 
 export const CalendarHeader = styled(View)`
   flex-direction: row;
@@ -10,4 +10,15 @@ export const MyCalendar = styled(View)`
   margin: 0 5%;
 `;
 
-export const CalendarContainer = styled(View)``;
+export const CalendarContainer = styled(View)`
+  align-items: center;
+  margin: 10% 0%;
+`;
+
+export const CalendarText = styled(Text)`
+  font-size: 25px;
+  font-weight: bold;
+  color: #bebebe;
+`;
+
+export const Container = styled(View)``;

--- a/src/pages/MyReserve/MyReservePage.tsx
+++ b/src/pages/MyReserve/MyReservePage.tsx
@@ -1,5 +1,12 @@
 import React, {useEffect, useState, useCallback, useRef} from 'react';
-import {SafeAreaView, Text, FlatList, View, ScrollView} from 'react-native';
+import {
+  SafeAreaView,
+  Text,
+  FlatList,
+  View,
+  ScrollView,
+  ActivityIndicator,
+} from 'react-native';
 import * as S from './Style'; // 스타일링 파일
 import {fetchReservations} from '../../apis/UserReserve/getReservation';
 import AsyncStorage from '@react-native-async-storage/async-storage'; // AsyncStorage 추가
@@ -59,7 +66,7 @@ const MyReservePage = () => {
   if (loading && page === 0) {
     return (
       <SafeAreaView>
-        <Text>로딩 중...</Text>
+        <ActivityIndicator size="large" color="#232074" />
       </SafeAreaView>
     );
   }

--- a/src/pages/ReserveProgramPage/ReserveProgramPage.tsx
+++ b/src/pages/ReserveProgramPage/ReserveProgramPage.tsx
@@ -16,11 +16,9 @@ const ReserveProgramPage = ({route}) => {
   const user = useSelector(state => state.auth.user);
 
   const navigation = useNavigation();
-  const {photographerId} = route.params;
-  const {programId} = route.params;
-  const {price} = route.params;
-  const {content} = route.params;
-  const {title} = route.params;
+  const {programId, title, content, price, photographerId} = route.params; // photographerId 추가
+
+  console.log('Program Details:', {programId, title, content, price});
 
   const handleDeleteProgram = async () => {
     await deleteReservations(programId);
@@ -32,9 +30,8 @@ const ReserveProgramPage = ({route}) => {
   };
   return (
     <SafeAreaView>
-      <ScrollView>
+      <ScrollView showsVerticalScrollIndicator={false}>
         <ContentsHeader text={'프로그램 세부내용'} />
-
         <S.Container>
           <ReserveProgram title={title} content={content} price={price} />
           {isAuthor ? (

--- a/src/pages/Settings/AuthorReserveAlarm/AuthorReserveAlarmPage.tsx
+++ b/src/pages/Settings/AuthorReserveAlarm/AuthorReserveAlarmPage.tsx
@@ -1,6 +1,13 @@
 //작가 알람설정 페이지 입니다.
 import React, {useEffect, useState} from 'react';
-import {SafeAreaView, Text, TextInput, Alert, StyleSheet} from 'react-native';
+import {
+  SafeAreaView,
+  Text,
+  TextInput,
+  Alert,
+  StyleSheet,
+  ScrollView,
+} from 'react-native';
 import {fetchAuthorReservationAlarm} from '../../../apis/AuthorReserve/getAuthorReservationAlarm';
 import LoginBtn from '../../../components/Login/LoginBtn';
 import {useNavigation} from '@react-navigation/native';
@@ -79,30 +86,32 @@ const AuthorReserveAlarmPage = () => {
 
   return (
     <SafeAreaView style={styles.container}>
-      <ContentsHeader text={'예약 알림 설정'} />
-      <S.SettingBox>
-        {isEditingAlarm ? (
-          <S.SettingTextInput
-            value={contents}
-            onChangeText={handleAlarmChange}
-            numberOfLines={5}
-            keyboardType="default"
-            placeholder=""
-            multiline={true}
-            textAlignVertical="top" // 텍스트 위쪽 정렬
-            autoFocus
-            onBlur={() => setisEditingAlarm(false)} // 포커스가 벗어나면 편집 모드 종료
-          />
-        ) : (
-          <S.SettingText
-            onPress={() => setisEditingAlarm(true)} // 텍스트 클릭 시 편집 모드로 전환
-          >
-            {contents}
-          </S.SettingText>
-        )}
+      <ScrollView showsVerticalScrollIndicator={false}>
+        <ContentsHeader text={'예약 알림 설정'} />
+        <S.SettingBox>
+          {isEditingAlarm ? (
+            <S.SettingTextInput
+              value={contents}
+              onChangeText={handleAlarmChange}
+              numberOfLines={5}
+              keyboardType="default"
+              placeholder=""
+              multiline={true}
+              textAlignVertical="top" // 텍스트 위쪽 정렬
+              autoFocus
+              onBlur={() => setisEditingAlarm(false)} // 포커스가 벗어나면 편집 모드 종료
+            />
+          ) : (
+            <S.SettingText
+              onPress={() => setisEditingAlarm(true)} // 텍스트 클릭 시 편집 모드로 전환
+            >
+              {contents}
+            </S.SettingText>
+          )}
 
-        <LoginBtn text="예약 전 알림 수정하기" onPress={handleSetting} />
-      </S.SettingBox>
+          <LoginBtn text="예약 전 알림 수정하기" onPress={handleSetting} />
+        </S.SettingBox>
+      </ScrollView>
     </SafeAreaView>
   );
 };

--- a/src/pages/Settings/AuthorReserveAlarm/Style.ts
+++ b/src/pages/Settings/AuthorReserveAlarm/Style.ts
@@ -19,4 +19,5 @@ export const SettingTextInput = styled(TextInput)`
 `;
 export const SettingBox = styled(View)`
   margin: 0% 10%;
+  margin-bottom: 5%;
 `;

--- a/src/pages/Settings/AuthorReservePlace/AuthorReservePlacePage.tsx
+++ b/src/pages/Settings/AuthorReservePlace/AuthorReservePlacePage.tsx
@@ -1,6 +1,13 @@
 //작가가 예약을 받을 장소를 조회하는 페이지 입니다.
 import React, {useEffect, useState} from 'react';
-import {SafeAreaView, Text, TextInput, Alert, StyleSheet} from 'react-native';
+import {
+  SafeAreaView,
+  Text,
+  TextInput,
+  Alert,
+  StyleSheet,
+  ScrollView,
+} from 'react-native';
 import {fetchAuthorReservationPlace} from '../../../apis/AuthorReserve/getAuthorReservationPlace';
 import LoginBtn from '../../../components/Login/LoginBtn';
 import {useNavigation} from '@react-navigation/native';
@@ -80,27 +87,29 @@ const AuthorReserveAlarmPage = () => {
 
   return (
     <SafeAreaView style={styles.container}>
-      <ContentsHeader text={'예약 장소 설정'} />
+      <ScrollView showsVerticalScrollIndicator={false}>
+        <ContentsHeader text={'예약 장소 설정'} />
 
-      <S.SettingContainer>
-        <S.SettingText>예약을 받을 장소</S.SettingText>
-        {isEditingPlace ? (
-          <S.SettingTextInput
-            value={contents}
-            onChangeText={handlePlaceChange}
-            keyboardType="default"
-            autoFocus
-            onBlur={() => setisEditingPlace(false)} // 포커스가 벗어나면 편집 모드 종료
-          />
-        ) : (
-          <S.SettingBoxText
-            onPress={() => setisEditingPlace(true)} // 텍스트 클릭 시 편집 모드로 전환
-          >
-            {contents}
-          </S.SettingBoxText>
-        )}
-        <LoginBtn text="장소 수정하기" onPress={handleSetting} />
-      </S.SettingContainer>
+        <S.SettingContainer>
+          <S.SettingText>예약을 받을 장소</S.SettingText>
+          {isEditingPlace ? (
+            <S.SettingTextInput
+              value={contents}
+              onChangeText={handlePlaceChange}
+              keyboardType="default"
+              autoFocus
+              onBlur={() => setisEditingPlace(false)} // 포커스가 벗어나면 편집 모드 종료
+            />
+          ) : (
+            <S.SettingBoxText
+              onPress={() => setisEditingPlace(true)} // 텍스트 클릭 시 편집 모드로 전환
+            >
+              {contents}
+            </S.SettingBoxText>
+          )}
+          <LoginBtn text="장소 수정하기" onPress={handleSetting} />
+        </S.SettingContainer>
+      </ScrollView>
     </SafeAreaView>
   );
 };

--- a/src/pages/Settings/AuthorReservePlace/Style.ts
+++ b/src/pages/Settings/AuthorReservePlace/Style.ts
@@ -3,6 +3,7 @@ import {View, Text, Pressable, TouchableOpacity, TextInput} from 'react-native';
 
 export const SettingContainer = styled(View)`
   margin: 0% 10%;
+  margin-bottom: 5%;
 `;
 export const SettingView = styled(View)`
   margin: 5% 0%;

--- a/src/pages/Settings/AuthorTimeFormatPage/AuthorTimeFormat.tsx
+++ b/src/pages/Settings/AuthorTimeFormatPage/AuthorTimeFormat.tsx
@@ -8,7 +8,10 @@ import {
   Button,
   StyleSheet,
   ScrollView,
+  Alert,
 } from 'react-native';
+import {useFocusEffect} from '@react-navigation/native';
+
 import ContentsHeader from '../../../components/ContentsHeader/ContentsHeader';
 import {fetchTimeFormat} from '../../../apis/AuthorTimeFormat/getAuthorTimeFormat';
 import CalendarBtn from '../../../components/Calendar/CalendarBtn/CalendarBtn';
@@ -35,19 +38,25 @@ const AuthorTimeFormatPage = () => {
     }
   };
 
-  useEffect(() => {
-    loadTimeFormat();
-  }, []);
-
+  useFocusEffect(
+    React.useCallback(() => {
+      loadTimeFormat(); // 화면이 포커스될 때 데이터 새로고침
+    }, []),
+  );
   const handleTimeFormat = () => {
     navigation.navigate('CreateAuthorTimeFormatPage');
   };
 
   //예약 시간 형식 삭제
   const handleDelete = async (reservationTimeFormatId: string) => {
-    console.log(reservationTimeFormatId);
-    await deleteAuthorTimeFormat(reservationTimeFormatId);
-    loadTimeFormat(); // 목록 새로고침
+    try {
+      await deleteAuthorTimeFormat(reservationTimeFormatId); // 삭제 API 호출
+      Alert.alert('삭제 완료', '예약 시간 형식을 삭제했습니다.');
+      loadTimeFormat(); // 삭제 후 목록 새로고침
+    } catch (error) {
+      Alert.alert('삭제 실패', '삭제하는 중 오류가 발생했습니다.');
+      console.error('삭제 오류:', error);
+    }
   };
 
   return (
@@ -64,10 +73,12 @@ const AuthorTimeFormatPage = () => {
           ListFooterComponent={
             <>
               <S.TimeBtnView>
-                <CalendarBtn
-                  text="예약 시간 생성하기"
-                  onPress={handleTimeFormat}
-                />
+                <S.BtnView>
+                  <CalendarBtn
+                    text="예약 시간 생성하기"
+                    onPress={handleTimeFormat}
+                  />
+                </S.BtnView>
               </S.TimeBtnView>
             </>
           }
@@ -82,7 +93,14 @@ const AuthorTimeFormatPage = () => {
           <S.TimeTextView>
             <S.TimeText>생성된 예약 시간이 없습니다.</S.TimeText>
           </S.TimeTextView>
-          <CalendarBtn text="예약 시간 생성하기" onPress={handleTimeFormat} />
+          <S.TimeBtnView>
+            <S.BtnView>
+              <CalendarBtn
+                text="예약 시간 생성하기"
+                onPress={handleTimeFormat}
+              />
+            </S.BtnView>
+          </S.TimeBtnView>
         </View>
       )}
     </SafeAreaView>

--- a/src/pages/Settings/AuthorTimeFormatPage/Style.ts
+++ b/src/pages/Settings/AuthorTimeFormatPage/Style.ts
@@ -25,3 +25,7 @@ export const TimeTextView = styled(View)`
 export const TimeBtnView = styled(View)`
   margin: 0% 5%;
 `;
+
+export const BtnView = styled(View)`
+  margin-bottom: 5%;
+`;

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -1,22 +1,30 @@
 //설정 페이지 입니다.
 import React from 'react';
-import {SafeAreaView, Text, View, ScrollView, StyleSheet} from 'react-native';
-import {useSelector} from 'react-redux';
+import {
+  SafeAreaView,
+  Text,
+  View,
+  ScrollView,
+  StyleSheet,
+  Alert,
+} from 'react-native';
+import {useSelector, useDispatch} from 'react-redux';
 import AuthorProfileComponent from '../../components/Profile/AuthorProfile/AuthorProfileComponent';
 import LogoutBtn from '../../components/Logout/LogoutBtn';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import axios from 'axios';
 import ContentsHeader from '../../components/ContentsHeader/ContentsHeader';
-import LoginBtn from '../../components/Login/LoginBtn';
 import {useNavigation} from '@react-navigation/native';
 import CalendarBtn from '../../components/Calendar/CalendarBtn/CalendarBtn';
 import * as S from './Style';
 import Icon from 'react-native-vector-icons/Ionicons';
-import Arrow from '../../icons/arrow.svg';
+import {logout} from '../../store/slices/authSlice';
 const Settings = () => {
   // Redux에서 상태 가져오기
   const isAuthor = useSelector(state => state.auth.user?.isAuthor);
   const user = useSelector(state => state.auth.user);
+
+  const dispatch = useDispatch();
   const navigation = useNavigation();
   const handleSetting = () => {
     navigation.navigate('AuthorReserveSettingPage');
@@ -36,6 +44,31 @@ const Settings = () => {
     navigation.navigate('AuthorWeekFormatPage');
   };
 
+  const handleLogout = async () => {
+    const token = await AsyncStorage.getItem('accessToken');
+    try {
+      if (token) {
+        // 로컬 스토리지에서 토큰 삭제
+        await AsyncStorage.removeItem('accessToken');
+        console.log('토큰 삭제 완료.');
+        dispatch(logout()); // 로그아웃 액션 디스패치 (isAuthenticated를 false로 설정)
+        Alert.alert('로그아웃 되었습니다.');
+        navigation.navigate('Home');
+      } else {
+        console.log('로그인 상태가 아닙니다.');
+        console.log('액세스 토큰: ', token);
+      }
+    } catch (error) {
+      console.error('로그아웃 중 오류 발생:', error);
+    }
+  };
+
+  const handleLogOutFormat = () => {
+    Alert.alert('로그아웃', '로그아웃 하시겠습니까?', [
+      {text: '예', onPress: handleLogout},
+      {text: '아니오'},
+    ]);
+  };
   return (
     <SafeAreaView style={styles.container}>
       <ScrollView showsVerticalScrollIndicator={false}>
@@ -45,48 +78,21 @@ const Settings = () => {
             <View>
               <S.SettingContents onPress={handleSetting}>
                 <S.SettingText>예약 설정</S.SettingText>
-                <Icon
-                  name={'arrow-down'}
-                  size={30}
-                  color={'#b1b1b1'}
-                  style={styles.rotatedIcon}
-                />
               </S.SettingContents>
               <S.SettingContents onPress={handleAlarmSetting}>
                 <S.SettingText>알림 설정</S.SettingText>
-                <Icon
-                  name={'arrow-down'}
-                  size={30}
-                  color={'#b1b1b1'}
-                  style={styles.rotatedIcon}
-                />
               </S.SettingContents>
               <S.SettingContents onPress={handlePlaceSetting}>
                 <S.SettingText>장소 설정</S.SettingText>
-                <Icon
-                  name={'arrow-down'}
-                  size={30}
-                  color={'#b1b1b1'}
-                  style={styles.rotatedIcon}
-                />
               </S.SettingContents>
               <S.SettingContents onPress={handleWeekFormat}>
                 <S.SettingText>요일별 예약 설정</S.SettingText>
-                <Icon
-                  name={'arrow-down'}
-                  size={30}
-                  color={'#b1b1b1'}
-                  style={styles.rotatedIcon}
-                />
               </S.SettingContents>
               <S.SettingContents onPress={handleTimeFormat}>
                 <S.SettingText>내 예약 시간 형식</S.SettingText>
-                <Icon
-                  name={'arrow-down'}
-                  size={30}
-                  color={'#b1b1b1'}
-                  style={styles.rotatedIcon}
-                />
+              </S.SettingContents>
+              <S.SettingContents onPress={handleLogOutFormat}>
+                <S.SettingText>로그아웃</S.SettingText>
               </S.SettingContents>
             </View>
           ) : (

--- a/src/pages/Settings/Style.ts
+++ b/src/pages/Settings/Style.ts
@@ -6,11 +6,12 @@ export const SettingContainer = styled(View)`
   padding: 0;
 `;
 
-export const SettingContents = styled(Pressable)`
+export const SettingContents = styled(TouchableOpacity)`
   width: 100%;
   background-color: transparent;
   align-items: flex-start;
   padding: 5%;
+  margin: 1% 2%;
   padding-bottom: 5%;
   flex-direction: row;
   justify-content: space-between;


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

# 📑 PR 요약
<!-- 이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요. -->
캘린더에서 내 예약 및 예약 내역, 예약 일자 마킹 표시 등 전반적인 캘린더 로직을 구현했다.

## 🔗 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->
#10 

## ☑ 작업 내용
<!-- 이 PR에서 어떤 작업이 있었는지 작성해주세요. -->
- feat : 특정 월의 예약 유무를 일별로 조회
- feat : 특정 일의 예약 목록을 조회
![image](https://github.com/user-attachments/assets/77d1f4f6-6921-456a-afcc-86919d231efb)

- 캘린더에서 날짜를 클릭하면 년월일과 그 날의 예약 목록이 조회된다. 사용자 및 작가 둘 다 동일하게 조회할 수 있다.

## ✅ 기타 사항

