### PR TITLE
feat : 공휴일 정보 적용 및 예약 페이지 캘린더 수정

### DIFF
--- a/src/apis/Calendar/getHoliday.ts
+++ b/src/apis/Calendar/getHoliday.ts
@@ -1,0 +1,26 @@
+//특정 달의 공휴일 정보를 가져오는 api
+import axios from 'axios';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import apiClient from '../getAccessToken';
+
+export const fetchHoliday = async yearMonth => {
+  try {
+    const params = {
+      yearMonth: yearMonth,
+    };
+    // axios 요청 보내기
+    const response = await apiClient.get('https://api.catsnap.net/holiday', {
+      params: params,
+    });
+
+    console.log('응답 데이터:', response.data); // 응답 데이터 확인
+    return response.data;
+  } catch (error) {
+    console.error('요청 실패:', error.response?.data || error.message);
+    if (error.response) {
+      console.log('응답 상태:', error.response.status);
+      console.log('응답 데이터:', error.response.data);
+    }
+    return null;
+  }
+};

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import * as S from './Style';
 import GestureRecognizer from 'react-native-swipe-gestures';
+import {fetchHoliday} from '../../apis/Calendar/getHoliday';
 
 const days = ['일', '월', '화', '수', '목', '금', '토'];
 const months = [
@@ -31,6 +32,20 @@ const Calendar = ({onDateSelect, onMonthChange, monthReserve}) => {
   const [selectedDay, setSelectedDay] = useState(null);
   const [checkDate, setCheckDate] = useState('');
   const [todayDay, setTodayDay] = useState(null);
+  const [holiday, setHoliday] = useState([]);
+
+  //공휴일 정보 가져오기
+  const handleHoliday = async (month: string) => {
+    try {
+      const response = await fetchHoliday(month);
+      setHoliday(response.data.holidayList);
+    } catch (error) {
+      console.log(
+        '휴일 가져오기 실패:',
+        error.message || '알 수 없는 오류 발생',
+      );
+    }
+  };
 
   useEffect(() => {
     const today = new Date();
@@ -43,6 +58,7 @@ const Calendar = ({onDateSelect, onMonthChange, monthReserve}) => {
     setCheckDate(`${year}-${formattedMonth}-${formattedDay}`);
     // 아무것도 선택되지 않았을 때 checkDate는 빈 문자열로 설정
     setCheckDate('');
+
     // 현재 월로 돌아오면 오늘 날짜 체크
     if (month === currentMonth.getMonth()) {
       setTodayDay(day); // 오늘 날짜 저장
@@ -50,6 +66,15 @@ const Calendar = ({onDateSelect, onMonthChange, monthReserve}) => {
       setTodayDay(null); // 다른 달로 넘어가면 오늘 날짜를 초기화
     }
   }, [currentMonth]);
+
+  useEffect(() => {
+    const yearMonth = currentMonth
+      .toISOString()
+      .split('-')
+      .slice(0, 2)
+      .join('-');
+    handleHoliday(yearMonth);
+  }, []); // 빈 배열로 설정해 최초 로딩 시 한 번만 실행
 
   const goToNextMonth = () => {
     const newMonth = new Date(
@@ -59,6 +84,9 @@ const Calendar = ({onDateSelect, onMonthChange, monthReserve}) => {
     );
     setCurrentMonth(newMonth);
     setSelectedDay(''); // 날짜 초기화
+
+    const yearMonth = newMonth.toISOString().split('-').slice(0, 2).join('-');
+    handleHoliday(yearMonth);
 
     if (onMonthChange) {
       onMonthChange(newMonth); // 부모 컴포넌트에 새로운 월을 전달
@@ -75,11 +103,13 @@ const Calendar = ({onDateSelect, onMonthChange, monthReserve}) => {
     setCurrentMonth(newMonth);
     setSelectedDay(''); // 날짜 초기화
 
+    const yearMonth = newMonth.toISOString().split('-').slice(0, 2).join('-');
+    handleHoliday(yearMonth);
+
     if (onMonthChange) {
       onMonthChange(newMonth); // 부모 컴포넌트에 새로운 월을 전달
     }
   };
-
   const generateMatrix = () => {
     const matrix = [days];
     const year = currentMonth.getFullYear();
@@ -95,15 +125,25 @@ const Calendar = ({onDateSelect, onMonthChange, monthReserve}) => {
           day: counter > 0 && counter <= maxDays ? counter : '',
           isInCurrentMonth: counter > 0 && counter <= maxDays,
           isReserved: false, // 기본값 false로 설정
+          isHoliday: false, // 공휴일 여부 추가
         };
 
-        // 해당 날짜가 monthReserve에 있는지 확인
+        // 해당 날짜가 holiday에 있는지 확인
         const formattedDate = `${year}-${(month + 1)
           .toString()
           .padStart(2, '0')}-${counter.toString().padStart(2, '0')}`;
-        const reservation = monthReserve.find(
-          item => item.reservationDate === formattedDate,
+        const isHoliday = holiday.some(
+          holidayItem => holidayItem.holidayDate === formattedDate,
         );
+
+        if (isHoliday) {
+          matrix[row][col].isHoliday = true; // 공휴일이면 true로 설정
+        }
+
+        // 예약된 날짜인지 확인
+        const reservation = Array.isArray(monthReserve)
+          ? monthReserve.find(item => item.reservationDate === formattedDate)
+          : null;
 
         if (reservation) {
           matrix[row][col].isReserved = true; // 예약된 날짜는 true로 설정
@@ -155,6 +195,7 @@ const Calendar = ({onDateSelect, onMonthChange, monthReserve}) => {
                     isInCurrentMonth={item.isInCurrentMonth}
                     selectedDay={selectedDay}
                     todayDay={todayDay}
+                    isHoliday={item.isHoliday}
                     itemDay={item.day}>
                     {rowIndex === 0 ? item : item.day}
                   </S.CellText>

--- a/src/components/Calendar/Style.ts
+++ b/src/components/Calendar/Style.ts
@@ -73,6 +73,7 @@ export const CellText = styled.Text<{
   selectedDay: number | null;
   todayDay: number | null;
   itemDay: number | null;
+  isHoliday: boolean; // 공휴일 여부를 위한 prop 추가
 }>`
   color: #000;
   font-size: 17px;
@@ -128,5 +129,11 @@ export const CellText = styled.Text<{
       font-size: 15px;
       font-weight: bold;
       color: #555; /* 요일 헤더 스타일 */
+    `}
+
+    ${({isHoliday}) =>
+    isHoliday &&
+    css`
+      color: red; /* 공휴일 텍스트 색 빨간색 */
     `}
 `;

--- a/src/pages/Reserve/UserReservePage.tsx
+++ b/src/pages/Reserve/UserReservePage.tsx
@@ -31,6 +31,7 @@ const UserReservePage = ({route}) => {
   const navigation = useNavigation();
 
   const [availableTimes, setAvailableTimes] = useState([]); // 날짜별 예약 가능한 시간 목록
+  const [monthReserve, setMonthReserve] = useState([]); // monthReserve를 빈 배열로 설정
 
   useEffect(() => {
     // startTime이 없으면 실행하지 않음
@@ -73,7 +74,11 @@ const UserReservePage = ({route}) => {
       console.log('선택된 시간:', time);
     }
   };
-
+  const onMonthChange = () => {
+    if (monthReserve.length === 0) {
+      return; // monthReserve가 빈 배열일 때 아무 작업도 하지 않음
+    }
+  };
   const handleSubmit = async () => {
     if (!selectedTime) {
       Alert.alert('', '예약 시간을 선택해 주세요.');
@@ -114,7 +119,7 @@ const UserReservePage = ({route}) => {
     <SafeAreaView style={styles.container}>
       <ScrollView showsVerticalScrollIndicator={false}>
         <ContentsHeader text="예약하기" />
-        <Calendar onDateSelect={setStartTime} />
+        <Calendar onDateSelect={setStartTime} onMonthChange={onMonthChange} />
 
         <S.TimeView>
           <Title text="예약 가능한 시간" />


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

# 📑 PR 요약
<!-- 이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요. -->
공휴일 정보를 가져오는 api를 연결했다. 캘린더에서 공휴일에 해당하는 날짜는 빨간색으로 처리된다.

## 🔗 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->
#13 

## ☑ 작업 내용
<!-- 이 PR에서 어떤 작업이 있었는지 작성해주세요. -->
- feat : 공휴일 정보 api 연결
- feat : 예약 페이지 캘린더 수정

## ✅ 기타 사항
- 공휴일 정보는 2년 정도로 제한되어 있다. 또한 서버의 DB가 초기화되면 공휴일 정보도 날아간다.