### PR TITLE
fix : 로그인 로직 수정

### DIFF
--- a/src/apis/Login/postAuthorLogin.ts
+++ b/src/apis/Login/postAuthorLogin.ts
@@ -9,16 +9,15 @@ export const LoginAuthor = async AuthorLogin => {
       'https://api.catsnap.net/photographer/signin/catsnap',
       AuthorLogin,
     );
+    console.log('로그인 응답 데이터:', response.data); // 응답 데이터 확인
 
     // 서버가 응답 헤더에 액세스 토큰을 포함하여 반환
     // 헤더에서 액세스 토큰 추출
-    const accessToken = response.headers.authorization;
+    //const accessToken = response.headers.authorization;
+    const accessToken = response.data.body.data.accessToken;
     if (accessToken) {
       // 액세스 토큰을 "Bearer "를 제거하고 AsyncStorage에 저장
-      await AsyncStorage.setItem(
-        'accessToken',
-        accessToken.replace('Bearer ', ''),
-      );
+      await AsyncStorage.setItem('accessToken', accessToken);
       console.log('액세스 토큰 저장 성공');
     } else {
       console.log('액세스 토큰이 응답 헤더에 없음');

--- a/src/apis/Login/postLogin.ts
+++ b/src/apis/Login/postLogin.ts
@@ -13,13 +13,12 @@ export const LoginUser = async userLogin => {
     console.log('로그인 응답 데이터:', response.data); // 응답 데이터 확인
 
     // 서버가 응답 헤더에 액세스 토큰을 포함하여 반환
-    const accessToken = response.headers.authorization;
+    //const accessToken = response.headers.authorization;
+    const accessToken = response.data.body.data.accessToken;
+
     if (accessToken) {
       // 액세스 토큰을 "Bearer "를 제거하고 AsyncStorage에 저장
-      await AsyncStorage.setItem(
-        'accessToken',
-        accessToken.replace('Bearer ', ''),
-      );
+      await AsyncStorage.setItem('accessToken', accessToken);
       console.log('액세스 토큰 저장 성공');
     } else {
       console.log('액세스 토큰이 응답 헤더에 없음');


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

# 📑 PR 요약
<!-- 이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요. -->
로그인 시 액세스 토큰을 헤더로 받아오는 로직을 바디로 받아오도록 수정한다.

## 🔗 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->

## ☑ 작업 내용
<!-- 이 PR에서 어떤 작업이 있었는지 작성해주세요. -->
- 액세스 토큰을 헤더로 받아오는 로직 삭제
- 액세스 토큰을 응답 바디의 data에서 받아오도록 변경
- 바디로 받아온 액세스 토큰을 바로 AsyncStorage에 저장하도록 수정

## ✅ 기타 사항
- 네이버 로그인 로직 수정이 추가되었다. 이후 테스트 필요
