### PR TITLE
refactor : 작가 예약 조회, 모델과 작가 로그인 시 상태 저장 로직 변경

### DIFF
--- a/src/apis/AuthorReserve/getAuthorReservation.ts
+++ b/src/apis/AuthorReserve/getAuthorReservation.ts
@@ -36,7 +36,7 @@ export const fetchAuthorReservations = async (type = 'All', page, size) => {
         },
       },
     );
-    console.log('전체 응답:', response);
+
     console.log('응답 데이터:', response.data); // 응답 데이터 확인
     return response.data;
   } catch (error) {

--- a/src/components/Home/MyReserve/MyReserve.tsx
+++ b/src/components/Home/MyReserve/MyReserve.tsx
@@ -4,20 +4,37 @@ import React from 'react';
 import {SafeAreaView} from 'react-native';
 import * as S from './Style';
 import {useNavigation} from '@react-navigation/native';
+import {useSelector} from 'react-redux';
 
 const MyReserve = ({reservation}) => {
   const navigation = useNavigation();
   const handleReserve = () => {
     navigation.navigate('MyReserve');
   };
+  const isAuthor = useSelector(state => state.auth.isAuthor);
+  const isUser = useSelector(state => state.auth.isUser);
 
-  const date = new Date(reservation.startTime);
-  // 원하는 형식으로 출력 (YYYY-MM-DD HH:mm)
-  const formattedDate = `${date.getFullYear()}-${String(
-    date.getMonth() + 1,
-  ).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}, ${String(
-    date.getHours(),
-  ).padStart(2, '0')}시 ${String(date.getMinutes()).padStart(2, '0')}분`;
+  let formattedDate = '';
+  if (isUser) {
+    //유저의 예약 데이터는 formattedDate 사용
+    // 원하는 형식으로 출력 (YYYY-MM-DD HH:mm)
+    const date = new Date(reservation.startTime);
+    formattedDate = `${date.getFullYear()}-${String(
+      date.getMonth() + 1,
+    ).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}, ${String(
+      date.getHours(),
+    ).padStart(2, '0')}시 ${String(date.getMinutes()).padStart(2, '0')}분`;
+  } else if (isAuthor) {
+    const startArray = reservation.startTime; // [2025, 4, 12, 13, 0]
+
+    const year = startArray[0];
+    const month = startArray[1];
+    const day = startArray[2];
+    const hour = startArray[3];
+    const minute = startArray[4] === 0 ? '00' : startArray[4];
+
+    formattedDate = `${year}-${month}-${day}, ${hour}시 ${minute}분`;
+  }
 
   return (
     <SafeAreaView style={{alignItems: 'center'}}>
@@ -30,10 +47,15 @@ const MyReserve = ({reservation}) => {
           style={{borderRadius: 20}}
         />
         <S.DateText>{formattedDate}</S.DateText>
-
-        <S.NameText numberOfLines={1}>
-          {reservation.photographerTinyInformationResponse.nickname} 작가
-        </S.NameText>
+        {isAuthor ? (
+          <S.NameText numberOfLines={1}>
+            {reservation.memberTinyInformationResponse.nickname} 님
+          </S.NameText>
+        ) : (
+          <S.NameText numberOfLines={1}>
+            {reservation.photographerTinyInformationResponse.nickname} 작가
+          </S.NameText>
+        )}
       </S.MyReserveContainer>
     </SafeAreaView>
   );

--- a/src/components/Profile/AuthorProfile/AuthorProfileComponent.tsx
+++ b/src/components/Profile/AuthorProfile/AuthorProfileComponent.tsx
@@ -23,8 +23,8 @@ const AuthorProfileComponent = () => {
   const [isTouchTwo, setIsTouchTwo] = useState(false);
   const [guide, setGuide] = useState(null); // 객체로 상태를 저장
   const [programs, setPrograms] = useState([]); // 프로그램 데이터를 저장할 상태
-  const isAuthor = useSelector(state => state.auth.user?.isAuthor);
-  const user = useSelector(state => state.auth.user);
+  const isAuthor = useSelector(state => state.auth.isAuthor);
+  const isUser = useSelector(state => state.auth.isUser);
 
   // 작가 탭 항목 터치 시 항목 출력
   const handleFeed = () => {

--- a/src/components/Profile/UserProfile/UserProfileComponent.tsx
+++ b/src/components/Profile/UserProfile/UserProfileComponent.tsx
@@ -11,8 +11,8 @@ import LogoutBtn from '../../Logout/LogoutBtn';
 const UserProfileComponent = () => {
   const navigation = useNavigation(); // 네비게이션 객체 가져오기
 
-  const isAuthor = useSelector(state => state.auth.user?.isAuthor);
-  const user = useSelector(state => state.auth.user);
+  const isAuthor = useSelector(state => state.auth.isAuthor);
+  const isUser = useSelector(state => state.auth.isUser);
 
   return (
     <SafeAreaView style={styles.container}>

--- a/src/components/Reserve/ReserveComponent/ReserveDataBox/ReserveDataBox.tsx
+++ b/src/components/Reserve/ReserveComponent/ReserveDataBox/ReserveDataBox.tsx
@@ -8,8 +8,8 @@ import Point from '../../../../icons/point.svg';
 const ReserveDataBox = ({item}) => {
   const [reservationStatus, setReservationStatus] = useState(item.state);
 
-  const isAuthor = useSelector(state => state.auth.user?.isAuthor);
-  const isUser = useSelector(state => state.auth.user);
+  const isAuthor = useSelector(state => state.auth.isAuthor);
+  const isUser = useSelector(state => state.auth.isUser);
   return (
     <SafeAreaView>
       {isAuthor ? (

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -25,8 +25,8 @@ const Home = () => {
   const [reservations, setReservations] = useState([]); // 예약 데이터를 저장할 상태
   const [loading, setLoading] = useState(true); // 로딩 상태
   const [error, setError] = useState(null); // 에러 상태 관리
-  const isAuthor = useSelector(state => state.auth.user?.isAuthor);
-  const isUser = useSelector(state => state.auth.user);
+  const isAuthor = useSelector(state => state.auth.isAuthor);
+  const isUser = useSelector(state => state.auth.isUser);
 
   // 예약 데이터를 가져오는 함수
   const getReservations = async () => {

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -65,8 +65,15 @@ const Login = () => {
 
     try {
       const response = await LoginUser(userLogin);
+      console.log('응답내역:', response);
       if (response) {
-        dispatch(loginSuccess({...response, isAuthor: false}));
+        if (response && response.body && response.body.data) {
+          const userData = response.body.data;
+          // 응답에 isAuthor가 없으면 false로 처리
+          const isAuthor = userData.isAuthor ?? false;
+
+          dispatch(loginSuccess({...userData, isAuthor})); // response.data만 넘기기
+        }
         Alert.alert(
           '', // 제목
           '로그인 되었습니다.', // 메시지

--- a/src/pages/MyCalendar/MyCalendar.tsx
+++ b/src/pages/MyCalendar/MyCalendar.tsx
@@ -23,8 +23,8 @@ import {fetchAuthorReserveMonth} from '../../apis/AuthorReserve/getAuthorReserve
 import ReserveColorBox from '../../components/Reserve/ReserveColorBox/ReserveColorBox';
 
 const MyCalendar = () => {
-  const isAuthor = useSelector(state => state.auth.user?.isAuthor);
-  const user = useSelector(state => state.auth.user);
+  const isAuthor = useSelector(state => state.auth.isAuthor);
+  const isUser = useSelector(state => state.auth.isUser);
   const navigation = useNavigation(); // 네비게이션 객체 가져오기
   const [date, setDate] = useState('');
   const [reserve, setReserve] = useState([]);
@@ -65,7 +65,7 @@ const MyCalendar = () => {
     //유저면 유저의 예약, 작가면 작가의 예약 업데이트
     if (isAuthor) {
       dayReserveAuthor(selectedDate);
-    } else if (user) {
+    } else if (isUser) {
       dayReserveUser(selectedDate);
     }
   };
@@ -103,7 +103,7 @@ const MyCalendar = () => {
           .catch(error => {
             console.log('예약 정보를 가져오는 데 오류 발생:', error);
           });
-      } else if (user) {
+      } else if (isUser) {
         console.log(month);
         fetchReserveMonth(month)
           .then(response => {
@@ -114,7 +114,7 @@ const MyCalendar = () => {
           });
       }
     }
-  }, [month, isAuthor, user]); // month가 변경될 때마다 API 호출
+  }, [month, isAuthor, isUser]); // month가 변경될 때마다 API 호출
 
   const [sortedReserve, setSortedReserve] = useState([]);
 
@@ -163,7 +163,7 @@ const MyCalendar = () => {
               keyExtractor={item => String(item.reservationId)}
               renderItem={({item}) => <ReserveAuthorBox item={item} />}
             />
-          ) : user ? (
+          ) : isUser ? (
             <FlatList
               scrollEnabled={false}
               nestedScrollEnabled={true} // ScrollView 안에서 FlatList 동작 허용

--- a/src/pages/Mypage/Mypage.tsx
+++ b/src/pages/Mypage/Mypage.tsx
@@ -14,8 +14,8 @@ import * as S from './Style';
 
 const Mypage = () => {
   // Redux에서 상태 가져오기
-  const isAuthor = useSelector(state => state.auth.user?.isAuthor);
-  const user = useSelector(state => state.auth.user);
+  const isAuthor = useSelector(state => state.auth.isAuthor);
+  const isUser = useSelector(state => state.auth.isUser);
   const navigation = useNavigation(); // 네비게이션 객체 가져오기
   const handleSetting = () => {
     navigation.navigate('Settings');

--- a/src/pages/ReserveProgramPage/ReserveProgramPage.tsx
+++ b/src/pages/ReserveProgramPage/ReserveProgramPage.tsx
@@ -12,8 +12,8 @@ import {useSelector} from 'react-redux';
 
 const ReserveProgramPage = ({route}) => {
   //유저정보 가져오기
-  const isAuthor = useSelector(state => state.auth.user?.isAuthor);
-  const user = useSelector(state => state.auth.user);
+  const isAuthor = useSelector(state => state.auth.isAuthor);
+  const isUser = useSelector(state => state.auth.isUser);
 
   const navigation = useNavigation();
   const {programId, title, content, price, photographerId} = route.params; // photographerId 추가

--- a/src/pages/ReserveState/ReserveState.tsx
+++ b/src/pages/ReserveState/ReserveState.tsx
@@ -22,8 +22,8 @@ const ReserveState = ({route}) => {
   const {item} = route.params; // 전달된 item을 받기
   const [reservationStatus, setReservationStatus] = useState(item.state);
 
-  const isAuthor = useSelector(state => state.auth.user?.isAuthor);
-  const isUser = useSelector(state => state.auth.user);
+  const isAuthor = useSelector(state => state.auth.isAuthor);
+  const isUser = useSelector(state => state.auth.isUser);
   const navigation = useNavigation(); // 네비게이션 객체 가져오기
 
   const handleReview = () => {

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -22,8 +22,8 @@ import {logout} from '../../store/slices/authSlice';
 
 const Settings = () => {
   // Redux에서 상태 가져오기
-  const isAuthor = useSelector(state => state.auth.user?.isAuthor);
-  const user = useSelector(state => state.auth.user);
+  const isAuthor = useSelector(state => state.auth.isAuthor);
+  const isUser = useSelector(state => state.auth.isUser);
 
   const dispatch = useDispatch();
   const navigation = useNavigation();

--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -5,7 +5,9 @@ import {createSlice} from '@reduxjs/toolkit';
 // 초기 상태 정의
 const initialState = {
   isAuthenticated: false, // 로그인 여부
-  user: null, // 로그인한 사용자 정보, 작가인지 유저인지 여부도 들어감
+  isUser: false, // 유저 여부
+  isAuthor: false, // 작가 여부
+  customer: null, // 로그인한 사용자 정보 (= 작가, 유저 상관없이 현재 로그인한 사람의 데이터)
 };
 
 // 슬라이스 생성
@@ -17,12 +19,16 @@ const authSlice = createSlice({
     // 로그인 성공 시 호출되는 액션
     loginSuccess: (state, action) => {
       state.isAuthenticated = true;
-      state.user = action.payload; // 사용자 정보 저장
+      state.customer = action.payload; // 사용자 정보 저장
+      state.isUser = action.payload.isAuthor ? false : true;
+      state.isAuthor = action.payload.isAuthor ?? false;
     },
     // 로그아웃 시 호출되는 액션
     logout: state => {
       state.isAuthenticated = false;
-      state.user = null;
+      state.isUser = false;
+      state.isAuthor = false;
+      state.customer = null;
     },
   },
 });


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

# 📑 PR 요약
<!-- 이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요. -->
- 작가의 예약 조회 시 발생하는 오류를 수정하고 예약 세부 내역을 조회할 수 있도록 구현했다.
- 모델과 작가로 로그인 시 상태를 저장하는 로직을 변경했다.

## 🔗 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->
#35 

## ☑ 작업 내용
<!-- 이 PR에서 어떤 작업이 있었는지 작성해주세요. -->
- 기존에는 isAuthor 항목만을 받아오고 이 요소가 있을 때 작가로 인식하도록 구현했으나 isAuthor, isUser 두 가지로 상태를 분리하여 모델과 작가 상태를 확실하게 구분지었다.

## ✅ 기타 사항
- 작가로 예약 조회 시에는 모델과 달리 배열 이름이 다르기 때문에 주의해야 한다.
- 마찬가지로 작가 예약 조회 시 날짜는 배열로 받아오기 때문에 적용 시 주의할 필요가 있다.
